### PR TITLE
BugFix/change_url_scheme

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array
      */
-    protected $proxies;
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        if (request()->isSecure()) {
+            \URL::forceScheme('https');
+        }
     }
 }


### PR DESCRIPTION
## Description / Purpose (checkpoints)
I couldn't open some resources on HTTPS request because of `asset()` is return string of URL scheme using `HTTP`. (vendor\laravel\framework\src\Illuminate\Routing\UrlGenerator.php)
```php
/**
 * Generate the URL to an application asset.
 *
 * @param  string  $path
 * @param  bool|null  $secure
 * @return string
 */
public function asset($path, $secure = null)
{
    if ($this->isValidUrl($path)) {
        return $path;
    }

    // Once we get the root URL, we will check to see if it contains an index.php
    // file in the paths. If it does, we will remove it since it is not needed
    // for asset paths, but only for routes to endpoints in the application.
    $root = $this->assetRoot
                ? $this->assetRoot
                : $this->formatRoot($this->formatScheme($secure));

    return $this->removeIndex($root).'/'.trim($path, '/');
}
```
So I added boot function that change URL scheme to use HTTPS if request is HTTPS.

And another problem, I think it will can't judge HTTPS request through proxy because of Heroku is using load balancer.
https://devcenter.heroku.com/articles/http-routing#routing

So I added wildcard of proxy to judge HTTPS request through trusted proxy. https://laravel.com/docs/5.7/requests#configuring-trusted-proxies

[*Asana task page*]
https://app.asana.com/0/1173796632051606/1176192161281177

## How To Test This PR
In my opinion, I can't test it because of I can't reproduce production environment in local environment. But this bug fix is not so high priority because of we can access to my system using HTTP protocol like this (http://sels-okurosawa.herokuapp.com/).
So I will apply it on next release day and I will test it in production.

 **Commands**
None

 **Screenshots**
- Error is show up on console when I access to my system using HTTPS. (https://sels-okurosawa.herokuapp.com/)
![page1](https://user-images.githubusercontent.com/56111888/82293752-01ce9680-99e8-11ea-8a46-21088ffc0b59.png)
