### PR TITLE
Feature/create_lesson_result_page

### DIFF
--- a/app/Answer.php
+++ b/app/Answer.php
@@ -12,4 +12,9 @@ class Answer extends Model
     {
         return $this->belongsTo('App\Choice', 'selected_choice_id');
     }
+
+    public function word()
+    {
+        return $this->belongsTo('App\Word');
+    }
 }

--- a/app/Answer.php
+++ b/app/Answer.php
@@ -7,4 +7,9 @@ use Illuminate\Database\Eloquent\Model;
 class Answer extends Model
 {
     protected $fillable = ['lesson_id', 'word_id', 'selected_choice_id'];
+
+    public function choice()
+    {
+        return $this->belongsTo('App\Choice', 'selected_choice_id');
+    }
 }

--- a/app/Choice.php
+++ b/app/Choice.php
@@ -10,4 +10,9 @@ class Choice extends Model
     use SoftDeletes;
 
     protected $fillable = ['word_id', 'content', 'correct_answer_flag'];
+
+    public function word()
+    {
+        return $this->belongsTo('App\Word');
+    }
 }

--- a/app/Http/Controllers/LessonController.php
+++ b/app/Http/Controllers/LessonController.php
@@ -27,9 +27,7 @@ class LessonController extends Controller
             $activity = new Activity();
             $activity->logActivity(Auth::id(), $lesson->id, 'App\Lesson');
 
-            // [Future task] If there is no remaining question, it will redirect to lesson result page
-            // https://app.asana.com/0/1173796632051606/1174497130657835
-            return;
+            return redirect()->route('lesson.result', ['lesson' => $lesson->id]);
         }
 
         $word = $questions->orderBy('id', 'asc')->first();
@@ -43,5 +41,10 @@ class LessonController extends Controller
         $lesson->saveAnswer($validated['wordId'], $validated['choiceId']);
 
         return redirect()->route('lesson.question', ['lesson' => $lesson->id]);
+    }
+
+    public function result(Lesson $lesson)
+    {
+        return view('lesson.result', compact('lesson'));
     }
 }

--- a/app/Lesson.php
+++ b/app/Lesson.php
@@ -31,6 +31,18 @@ class Lesson extends Model
         return $this->hasMany('App\Answer');
     }
 
+    public function choices()
+    {
+        return $this->hasManyThrough(
+            'App\Choice',
+            'App\Answer',
+            'lesson_id',
+            'id',
+            'id',
+            'selected_choice_id'
+        );
+    }
+
     /**
      * Create new lesson or return already exists lesson
      *

--- a/resources/views/components/category-list.blade.php
+++ b/resources/views/components/category-list.blade.php
@@ -9,7 +9,9 @@
                   <p class="card-text">{{ $category->description }}</p>
                   <div class="text-right">
                         @if($category->howManyRemainingWords(Auth::id()) == 0)
-                            <a href="#" class="btn btn-block btn-light">Already learned</a>
+                            <a href="{{ route('lesson.result', ['lesson' => $category->lessons->where('user_id', Auth::id())->first()->id]) }}" class="btn btn-block btn-light">
+                                Show result
+                            </a>
                         @else
                             <a href="{{ route('lesson.start', ['category' => $category->id]) }}" class="btn btn-block btn-primary">
                                 Start<br>({{ $category->howManyRemainingWords(Auth::id()) }} words left)

--- a/resources/views/components/lesson-result.blade.php
+++ b/resources/views/components/lesson-result.blade.php
@@ -1,0 +1,41 @@
+<div class="bg-white border shadow p-4 mb-4">
+    <h1 class="mb-4">
+        {{ $lesson->category->title }}
+        (
+            Result:
+            {{ $lesson->choices->where('correct_answer_flag', true)->count() }}
+            of
+            {{ $lesson->category->words->count() }}
+        )
+    </h1>
+    <table class="table text-center">
+        <thead>
+            <th>Result</th>
+            <th>Word</th>
+            <th>Your Answer</th>
+            <th>Correct Answer</th>
+        </thead>
+        <tbody>
+            @foreach($lesson->answers as $answer)
+                <tr>
+                    <td>
+                        @if($answer->choice->correct_answer_flag)
+                            <i class="far fa-circle text-success"></i>
+                        @else
+                            <i class="fas fa-times text-danger"></i>
+                        @endif
+                    </td>
+                    <td>
+                        {{ $answer->choice->word->content }}
+                    </td>
+                    <td>
+                        {{ $answer->choice->content }}
+                    </td>
+                    <td>
+                        {{ $answer->choice->word->choices->where('correct_answer_flag', true)->first()->content }}
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>

--- a/resources/views/components/lesson-result.blade.php
+++ b/resources/views/components/lesson-result.blade.php
@@ -26,13 +26,13 @@
                         @endif
                     </td>
                     <td>
-                        {{ $answer->choice->word->content }}
+                        {{ $answer->word->content }}
                     </td>
                     <td>
                         {{ $answer->choice->content }}
                     </td>
                     <td>
-                        {{ $answer->choice->word->choices->where('correct_answer_flag', true)->first()->content }}
+                        {{ $answer->word->choices->where('correct_answer_flag', true)->first()->content }}
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/components/user-activity.blade.php
+++ b/resources/views/components/user-activity.blade.php
@@ -28,12 +28,12 @@
                             </a>
                             <span>
                                 learned
-                                {{ $activity->activityMorph->answers->count() }}
+                                {{ $activity->activityMorph->choices->where('correct_answer_flag', true)->count() }}
                                 of
                                 {{ $activity->activityMorph->category->words->count() }}
                                 words
                             </span>
-                            <a href="#">{{ $activity->activityMorph->category->title }}</a>
+                            <a href="{{ route('lesson.result', ['lesson' => $activity->activityMorph->id]) }}">{{ $activity->activityMorph->category->title }}</a>
                         @endif
                     </h3>
                 </div>

--- a/resources/views/lesson/result.blade.php
+++ b/resources/views/lesson/result.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    @include('components.lesson-result', ['lesson' => $lesson])
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,6 +40,7 @@ Route::middleware('auth', 'throttle:60,1')->group(function () {
     // Lesson
     Route::prefix('lesson')->name('lesson.')->group(function () {
         Route::get('/start/{category}', 'LessonController@start')->name('start');
+        Route::get('/{lesson}/result', 'LessonController@result')->name('result');
 
         // only user who created lesson can access
         Route::middleware('lesson')->group(function () {


### PR DESCRIPTION
## Description / Purpose (checkpoints)
These change provide feature that `User` can see the result of lesson.

These are summary what I did.
- I created `Lesson result` page.
- I added relationship to model of `Answer` , `Choice` and `Lesson`.
- I added the link on `Category list` page and `User's Activity`. This link can move to `Lesson result page`.

[*Asana task page*]
https://app.asana.com/0/1173796632051606/1174497130657835

## How To Test This PR
1. Login to E-learning system as user. ( `/login` )
2. Click the link of `Categories` on navbar then you will move to `Category list` page. (`/category/list`)
3. Push `Start` button and then Take the lesson. (`/lesson/{lesson_id}/question`)
4. If you answer last question, you will move to `Lesson result` page. (`/lesson/{lesson_id}/result`)
5. `Lesson result` page will display these data:
- Category title
- How many correct answer in this lesson
- Result
- Word
- Your Answer
- Correct Answer
6. Other way, you can open `Lesson result` page if you push `Show result` button on `Category list` page or link of the category title in `User's Activities`.

※If there is no category, you have to login as `Admin` then create new category.
※If you want to login as `Admin`, you have to change value of `Users.admin_flag` to 1 at database.

 **Commands**
None

 **Screenshots**
- If you already took lesson, `Show result` button will display instead of  `Start` button.
![page1](https://user-images.githubusercontent.com/56111888/82636235-1c4d7d80-9c3d-11ea-90e1-9a9e5e2d0081.png)

- `Lesson result` page
![page2](https://user-images.githubusercontent.com/56111888/82636257-27a0a900-9c3d-11ea-9720-135dd34ae903.png)
