### PR TITLE
Feature/create_show_all_learned_words_page

### DIFF
--- a/app/Http/Controllers/WordController.php
+++ b/app/Http/Controllers/WordController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\User;
+use Illuminate\Http\Request;
+
+class WordController extends Controller
+{
+    public function learned(User $user)
+    {
+        $answers = $user->answers()->paginate(20);
+
+        return view('word.learned', compact(['user', 'answers']));
+    }
+}

--- a/resources/views/components/user-individual.blade.php
+++ b/resources/views/components/user-individual.blade.php
@@ -45,7 +45,7 @@
 
         <div class="text-center">
             <p>
-                <a href="#">
+                <a href="{{ route('word.learned', ['user' => $user->id]) }}">
                     Learned {{ $user->answers->count() }} words
                 </a>
             </p>

--- a/resources/views/components/user-profile.blade.php
+++ b/resources/views/components/user-profile.blade.php
@@ -19,7 +19,7 @@
 
         <div class="d-flex justify-content-around">
             <div class="p-2">
-                <a class="d-inline-block btn btn-primary" href="#">
+                <a class="d-inline-block btn btn-primary" href="{{ route('word.learned', ['user' => $user->id]) }}">
                     <span class="font-weight-bold">{{ $user->answers->count() }}</span>
                     <p>words learned</p>
                 </a>

--- a/resources/views/components/word-learned-list.blade.php
+++ b/resources/views/components/word-learned-list.blade.php
@@ -1,0 +1,41 @@
+<div class="bg-white border shadow p-4 mb-4">
+    <h1 class="mb-4">Words learned</h1>
+    
+    @if (count($answers) == 0)
+        <hr>
+        <h3>No learned word.</h3>
+    @else
+        <table class="table text-center">
+            <thead>
+                <th>Word</th>
+                <th>Your Answer</th>
+                <th>Correct Answer</th>
+            </thead>
+            <tbody>
+                @foreach($answers as $answer)
+                    <tr>
+                        <td>
+                            {{ $answer->word->content }}
+                        </td>
+                        <td>
+                            <span class="{{ $answer->choice->correct_answer_flag ? 'text-success font-weight-bold' : '' }}">
+                                {{ $answer->choice->content }}
+                            </span>
+                        </td>
+                        <td>
+                            @if(!$answer->choice->correct_answer_flag)
+                                <span class="text-success font-weight-bold">
+                                    {{ $answer->word->choices->where('correct_answer_flag', true)->first()->content }}
+                                </span>
+                            @endif
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+
+        <div class="d-flex justify-content-center">
+            {{ $answers->links() }}
+        </div>
+    @endif
+</div>

--- a/resources/views/word/learned.blade.php
+++ b/resources/views/word/learned.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <div class="row">
+        <div class="col-lg-4 col-md-5 p-4">
+            @include('components.user-individual', ['user', $user])
+        </div>
+
+        <div class="col-lg-8 col-md-7 p-4">
+            @include('components.word-learned-list', ['answers', $answers])
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,11 @@ Route::middleware('auth', 'throttle:60,1')->group(function () {
             Route::post('/{lesson}/answer', 'LessonController@answer')->name('answer');
         });
     });
+
+    // Word
+    Route::prefix('word')->name('word.')->group(function () {
+        Route::get('/learned/{user}', 'WordController@learned')->name('learned');
+    });
 });
 
 // Admin routes


### PR DESCRIPTION
## Description / Purpose (checkpoints)
These change provide feature that `User` can see all words that user already learned

These are summary what I did.
- I created `Words learned` page.
- I added the link on `Home` page and `User profile` page. This link can move to `Words learned` page.

[*Asana task page*]
https://app.asana.com/0/1173796632051606/1174497130657825

## How To Test This PR
1. Login to E-learning system as user. ( `/login` )
2. Click the `words learned` button on `Home` page then you will move to `Words learned` page. (`/word/learned/{user_id}`)
3. Other way, you can open `Words learned` page if you click the link of `Learned * words` at 'User profile' page.

 **Commands**
None

 **Screenshots**
- `Words learned` page
![page1](https://user-images.githubusercontent.com/56111888/82647940-e36bd380-9c51-11ea-8722-72a4ffedd615.png)
